### PR TITLE
Rework matrix generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,25 +283,25 @@ lazy val core =
       List(scala212, scala213, scala3),
       List(VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native),
       List(LibraryAxis.V1, LibraryAxis.V2)
-    ) {
+    )(
       // 1: Completely remove the `Scala 3 + Scala Native` combination
-      case (scalaV, axes)
-          if scalaV.isScala3 && axes.contains(VirtualAxis.native) =>
-        MatrixAction.Skip
-
+      MatrixAction((scalaV, axes) =>
+        scalaV.isScala3 && axes.contains(VirtualAxis.native)
+      ).Skip,
       // 2: Disable Scalafix plugin for all Scala 3 projects
-      case (scalaV, _) if scalaV.isScala3 =>
-        MatrixAction.Configure(_.disablePlugins(ScalafixPlugin))
-
-      // 3: Not publish any of the Scala 2 projects on Scala.js
-      case (scalaV, axes) if !scalaV.isScala3 && axes.contains(VirtualAxis.js) =>
-        MatrixAction.Settings(
-          Seq(
-            publish / skip := true,
-            publishLocal / skip := true
-          )
+      MatrixAction
+        .ForScala(_.isScala3)
+        .Configure(_.disablePlugins(ScalafixPlugin)),
+      // 3: Not publish any of the Scala 2 projects on Scala.js *
+      MatrixAction((scalaV, axes) =>
+        scalaV.isScala2 && axes.contains(VirtualAxis.js)
+      ).Settings(
+        Seq(
+          publish / skip := true,
+          publishLocal / skip := true
         )
-    }
+      )
+    )
 ```
 
 **(See the version of this snippet in the [test file](core/src/sbt-test/commandMatrix/extra/build.sbt) which is verified on CI and is guaranteed to be correct)**

--- a/core/src/sbt-test/commandMatrix/extra/test
+++ b/core/src/sbt-test/commandMatrix/extra/test
@@ -24,3 +24,20 @@
 > core-V2JS2_12/notPublished
 -> core-V1JS3/notPublished
 -> core-V2JS3/notPublished
+
+# Requirement 4
+# Correct plugins are added: Scala.js
+> core-V1JS/jsEnvInput
+> core-V2JS/jsEnvInput
+> core-V1JS2_12/jsEnvInput
+> core-V2JS2_12/jsEnvInput
+> core-V1JS3/jsEnvInput
+> core-V2JS3/jsEnvInput
+# Correct plugins are added: Scala.Native
+> core-V2Native/nativeConfig
+> core-V1Native/nativeConfig
+> core-V2Native2_12/nativeConfig
+> core-V1Native2_12/nativeConfig
+
+
+


### PR DESCRIPTION
Instead of a single big cell refinement, accept multiple steps. This should help with code sharing, and also solve the problem of falling through the pattern match.

This also fixes #6 in a hacky, copy-pasty way. Revisit once https://github.com/sbt/sbt-projectmatrix/pull/64 is merged/superseded by something better.